### PR TITLE
removed pyqt and qtpy from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ AUTHOR = 'Gaetan de Menten, Geert Bryon, Johan Duyck, Alix Damman'
 AUTHOR_EMAIL = 'gdementen@gmail.com'
 DESCRIPTION = "Graphical User Interface for LArray library"
 LONG_DESCRIPTION = readlocal("README.rst")
-INSTALL_REQUIRES = ['larray', 'pyqt', 'qtpy']
+INSTALL_REQUIRES = ['larray'] # pyqt and qtpy required (see conda recipe)
 TESTS_REQUIRE = ['pytest']
 SETUP_REQUIRES = ['pytest-runner']
 


### PR DESCRIPTION
I should have tried 

 >python setup.py install 

earlier. It doesn't work. 

pyqt and qtpy will be installed automatically as long as users use conda. 