### PR TITLE
fixed call to new in viewer + reset filters

### DIFF
--- a/larray_editor/api.py
+++ b/larray_editor/api.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     # file = abspath('test_session.xlsx')
     # ses.save(file)
 
-    edit(la.Session(arr2=arr2))
+    edit(ses)
     # edit(ses)
     # edit(file)
     # edit('fake_path')

--- a/larray_editor/arrayadapter.py
+++ b/larray_editor/arrayadapter.py
@@ -99,9 +99,14 @@ class LArrayDataAdapter(object):
         self.filtered_data = self.la_data[self.current_filter]
         if np.isscalar(self.filtered_data):
             self.filtered_data = la.aslarray(self.filtered_data)
-        axes = self.get_axes()
-        xlabels = self.get_xlabels()
-        ylabels = self.get_ylabels()
+        if len(self.filtered_data) == 0:
+            axes = [[]]
+            xlabels = [[]]
+            ylabels = [[]]
+        else:
+            axes = self.get_axes()
+            xlabels = self.get_xlabels()
+            ylabels = self.get_ylabels()
         data_2D = self.get_2D_data()
         changes_2D = self.get_changes_2D()
         self.axes_model.set_data(axes)

--- a/larray_editor/arrayadapter.py
+++ b/larray_editor/arrayadapter.py
@@ -88,6 +88,8 @@ class LArrayDataAdapter(object):
     # - set_data (which reset the current filter)
     # - update_data (which sets new data but keeps current filter unchanged)
     def set_data(self, data, bg_gradient=None, bg_value=None, current_filter=None):
+        if current_filter is None:
+            self.current_filter = {}
         self.la_data = la.aslarray(data)
         self.update_filtered_data(current_filter)
         self.data_model.set_background(bg_gradient, bg_value)

--- a/larray_editor/arraywidget.py
+++ b/larray_editor/arraywidget.py
@@ -690,11 +690,12 @@ class ArrayEditorWidget(QWidget):
 
         filters_layout = self.filters_layout
         clear_layout(filters_layout)
-        filters_layout.addWidget(QLabel(_("Filters")))
-        for axis, display_name in zip(axes, display_names):
-            filters_layout.addWidget(QLabel(display_name))
-            filters_layout.addWidget(self.create_filter_combo(axis))
-        filters_layout.addStretch()
+        if len(la_data) > 0:
+            filters_layout.addWidget(QLabel(_("Filters")))
+            for axis, display_name in zip(axes, display_names):
+                filters_layout.addWidget(QLabel(display_name))
+                filters_layout.addWidget(self.create_filter_combo(axis))
+            filters_layout.addStretch()
         self.data_adapter.update_filtered_data({})
 
     def _update(self, la_data):

--- a/larray_editor/editor.py
+++ b/larray_editor/editor.py
@@ -498,7 +498,7 @@ class MappingEditor(QMainWindow):
     def new(self):
         if self._ask_to_save_if_unsaved_modifications():
             self._reset()
-            self.arraywidget.set_data(zeros(0))
+            self.arraywidget.set_data(np.empty(0))
             self.arraywidget.set_filters()
             self.set_current_file(None)
             self._unsaved_modifications = False


### PR DESCRIPTION
Well, we need to adapt the Adapter to handle 0-length LArray and scalar objects.
I don't know how to do this properly...
This PR is just to avoid weird stuff displayed when opening new empty editor or clicking on new. 