### PR TITLE
fix #85 : display dtype (in title)

### DIFF
--- a/larray_editor/editor.py
+++ b/larray_editor/editor.py
@@ -478,8 +478,9 @@ class MappingEditor(QMainWindow):
             # array info
             shape = ['{} ({})'.format(display_name, len(axis))
                      for display_name, axis in zip(array.axes.display_names, array.axes)]
-        # if it's not an LArray, it must be a Numpy ndarray
         else:
+            # if it's not an LArray, it must be a Numpy ndarray
+            assert isinstance(array, np.ndarray)
             shape = [str(length) for length in array.shape]
         # name + shape + dtype
         array_info = ' x '.join(shape) + ' [{}]'.format(dtype)

--- a/larray_editor/editor.py
+++ b/larray_editor/editor.py
@@ -478,8 +478,13 @@ class MappingEditor(QMainWindow):
             axes_info = ' x '.join("%s (%d)" % (display_name, len(axis))
                                    for display_name, axis
                                    in zip(axes.display_names, axes))
-            title += [(name + ': ' + axes_info) if name else axes_info]
-        # name of non-LArray displayed item (if not None)
+            dtype = ' [{}]'.format(array.dtype.name)
+            title += [(name + ': ' + axes_info + dtype) if name else axes_info + dtype]
+        elif isinstance(array, np.ndarray):
+            shape = ' x '.join('({})'.format(length) for length in array.shape)
+            dtype = ' [{}]'.format(array.dtype.name)
+            title += [(name + ': ' + shape + dtype) if name else shape + dtype]
+        # name of non-LArray/Numpy displayed item (if not None)
         elif name:
             title = [name]
         # extra info


### PR DESCRIPTION
+ display shape + dtype of Numpy ndarray in title

No need to change Tooltip associated with listwidget. It uses `array.info` which will be changed in larray project (see PR https://github.com/liam2/larray/pull/459).