### PR TITLE
fix #138 : replaced 'liam2' by 'larray-project' 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
     # - sudo ln -s /run/shm /dev/shm
 
     # clone larray repository
-    - git clone https://github.com/liam2/larray.git larray
+    - git clone https://github.com/larray-project/larray.git larray
 
 install:
     # Setup environment

--- a/larray_editor/utils.py
+++ b/larray_editor/utils.py
@@ -40,7 +40,7 @@ urls = {"fpb": "http://www.plan.be/index.php?lang=en",
         "doc_tutorial": "{}/tutorial.html".format(doc),
         "doc_api": "{}/api.html".format(doc),
         "new_issue_editor": "https://github.com/larray-project/larray-editor/issues/new",
-        "new_issue_larray": "https://github.com/liam2/larray/issues/new",
+        "new_issue_larray": "https://github.com/larray-project/larray/issues/new",
         "new_issue_larray_eurostat": "https://github.com/larray-project/larray_eurostat/issues/new",
         "announce_group": "https://groups.google.com/d/forum/larray-announce",
         "users_group": "https://groups.google.com/d/forum/larray-users"}


### PR DESCRIPTION
in all references to the larray repository.

Wait for https://github.com/liam2/larray/issues/502 to be closed before to merge this PR.